### PR TITLE
Add queue for substrate events and stellar improvements

### DIFF
--- a/tfchain_bridge/go.mod
+++ b/tfchain_bridge/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/go-errors/errors v0.0.0-20150906023321-a41850380601 // indirect
 	github.com/go-ole/go-ole v1.2.4 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect
-	github.com/gologme/log v1.2.0
 	github.com/gorilla/schema v1.1.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/gtank/merlin v0.1.1 // indirect
@@ -38,8 +37,7 @@ require (
 	github.com/rs/zerolog v1.25.0
 	github.com/segmentio/go-loggly v0.5.1-0.20171222203950-eb91657e62b2 // indirect
 	github.com/sirupsen/logrus v1.4.2 // indirect
-	github.com/stellar/go v0.0.0-20210920115508-0599e8167019
-	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a // indirect
+	github.com/stellar/go v0.0.0-20210922122349-e6f322c047c5
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/vedhavyas/go-subkey v1.0.2
@@ -55,4 +53,5 @@ require (
 	github.com/libp2p/go-openssl v0.0.7 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
+	github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a // indirect
 )

--- a/tfchain_bridge/go.sum
+++ b/tfchain_bridge/go.sum
@@ -245,8 +245,6 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8l
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3-0.20201103224600-674baa8c7fc3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/gologme/log v1.2.0 h1:Ya5Ip/KD6FX7uH0S31QO87nCCSucKtF44TLbTtO7V4c=
-github.com/gologme/log v1.2.0/go.mod h1:gq31gQ8wEHkR+WekdWsqDuf8pXTUZA9BnnzTuPz1Y9U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
@@ -329,6 +327,7 @@ github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19y
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
+github.com/ipfs/go-cid v0.0.7 h1:ysQJVJA3fNDF1qigJbsSQOdjhVLsOEoPdh0+R97k3jY=
 github.com/ipfs/go-cid v0.0.7/go.mod h1:6Ux9z5e+HpkQdckYoX1PG/6xqKspzlEIR5SDmgqgC/I=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jarcoal/httpmock v0.0.0-20161210151336-4442edb3db31 h1:Aw95BEvxJ3K6o9GGv5ppCd1P8hkeIeEJ30FO+OhOJpM=
@@ -351,6 +350,7 @@ github.com/julienschmidt/httprouter v1.1.1-0.20170430222011-975b5c4c7c21/go.mod 
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/jwilder/encoding v0.0.0-20170811194829-b4e1701a28ef/go.mod h1:Ct9fl0F6iIOGgxJ5npU/IUOhOhqlVrGjyIZc8/MagT0=
+github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -380,6 +380,7 @@ github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0/go.mod h1:vmVJ0l/dxyfGW6Fm
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=
 github.com/libp2p/go-buffer-pool v0.0.2/go.mod h1:MvaB6xw5vOrDl8rYZGLFdKAuk/hRoRZd1Vi32+RXyFM=
 github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
 github.com/libp2p/go-libp2p-core v0.10.0 h1:jFy7v5Muq58GTeYkPhGzIH8Qq4BFfziqc0ixPd/pP9k=
@@ -407,6 +408,7 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4f
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 h1:hLDRPB66XQT/8+wG9WsDpiCvZf1yKO7sz7scAjSlBa0=
 github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643/go.mod h1:43+3pMjjKimDBf5Kr4ZFNGbLql1zKkbImw+fZbw3geM=
+github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
@@ -419,15 +421,22 @@ github.com/moul/http2curl v0.0.0-20161031194548-4e24498b31db h1:eZgFHVkk9uOTaOQL
 github.com/moul/http2curl v0.0.0-20161031194548-4e24498b31db/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.3/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
+github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
 github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
+github.com/multiformats/go-base32 v0.0.3 h1:tw5+NhuwaOjJCC5Pp82QuXbrmLzWg7uxlMFp8Nq/kkI=
 github.com/multiformats/go-base32 v0.0.3/go.mod h1:pLiuGC8y0QR3Ue4Zug5UzK9LjgbkL8NSQj0zQ5Nz/AA=
+github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ89tUg4F4=
 github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
+github.com/multiformats/go-multiaddr v0.2.2 h1:XZLDTszBIJe6m0zF6ITBrEcZR73OPUhCBBS9rYAuUzI=
 github.com/multiformats/go-multiaddr v0.2.2/go.mod h1:NtfXiOtHvghW9KojvtySjH5y0u0xW5UouOmQQrn6a3Y=
+github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
+github.com/multiformats/go-multihash v0.0.14 h1:QoBceQYQQtNUuf6s7wHxnE2c8bhbMqhfGzNI032se/I=
 github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-varint v0.0.5/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
+github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2W/KhfNY=
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
@@ -516,6 +525,7 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 h1:RC6RW7j+1+HkWaX/Yh71Ee5ZHaHYt7ZP4sQgUrm6cDU=
 github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572/go.mod h1:w0SWMsp6j9O/dk4/ZpIhL+3CkG8ofA2vuv7k+ltqUMc=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/cast v0.0.0-20150508191742-4d07383ffe94/go.mod h1:r2rcYCSwa1IExKTDiTfzaxqT2FNHs8hODu4LnUfgKEg=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -530,8 +540,8 @@ github.com/spf13/viper v0.0.0-20150621231900-db7ff930a189/go.mod h1:A8kyI5cUJhb8
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
 github.com/steakknife/bloomfilter v0.0.0-20180922174646-6819c0d2a570/go.mod h1:8OR4w3TdeIHIh1g6EMY5p0gVNOovcWC+1vpc7naMuAw=
 github.com/steakknife/hamming v0.0.0-20180906055917-c99c65617cd3/go.mod h1:hpGUWaI9xL8pRQCTXQgocU38Qw1g0Us7n5PxxTwTCYU=
-github.com/stellar/go v0.0.0-20210920115508-0599e8167019 h1:lF+ccVzjcoxv1H3VTebPUu3TbPbLorCeZ1eDgFB6pRo=
-github.com/stellar/go v0.0.0-20210920115508-0599e8167019/go.mod h1:4JAtqxZ9sVun3vwOD3YRF8y3eCDeY7SQa+FyQHAacRg=
+github.com/stellar/go v0.0.0-20210922122349-e6f322c047c5 h1:IWoP0qUfMpin06HFd6zcZbBq6D2tptOip16MM0KHZ1o=
+github.com/stellar/go v0.0.0-20210922122349-e6f322c047c5/go.mod h1:Q1bUL0SgR4IkPkCTr0FW9rj+fKROQfJh/6XHmLMI6ks=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a h1:GnM0ArRp7EDbaTiFhSp/CLgyk2cacXxdUklqJmdJs1Q=
 github.com/stellar/go-xdr v0.0.0-20201028102745-f80a23dac78a/go.mod h1:yoxyU/M8nl9LKeWIoBrbDPQ7Cy+4jxRcWcOayZ4BMps=
 github.com/stellar/throttled v2.2.3-0.20190823235211-89d75816f59d+incompatible/go.mod h1:7CJ23pXirXBJq45DqvO6clzTEGM/l1SfKrgrzLry8b4=

--- a/tfchain_bridge/pkg/substrate/blocks.go
+++ b/tfchain_bridge/pkg/substrate/blocks.go
@@ -48,3 +48,7 @@ func (s *SubstrateClient) FetchEventsForBlockRange(start uint32, end uint32) (ty
 
 	return key, rawSet, nil
 }
+
+func (s *SubstrateClient) GetBlock(block types.Hash) (*types.SignedBlock, error) {
+	return s.cl.RPC.Chain.GetBlock(block)
+}

--- a/tfchain_bridge/pkg/substrate/burning.go
+++ b/tfchain_bridge/pkg/substrate/burning.go
@@ -18,10 +18,11 @@ var (
 )
 
 type BurnTransaction struct {
-	Block      types.U32
-	Amount     types.U64
-	Target     AccountID
-	Signatures []pkg.StellarSignature
+	Block          types.U32
+	Amount         types.U64
+	Target         AccountID
+	Signatures     []pkg.StellarSignature
+	SequenceNumber types.U64
 }
 
 func unsubscribe(sub *state.StorageSubscription) {
@@ -29,35 +30,35 @@ func unsubscribe(sub *state.StorageSubscription) {
 	sub.Unsubscribe()
 }
 
-func (s *SubstrateClient) ProposeBurnTransactionOrAddSig(identity *Identity, txID uint64, target AccountID, amount *big.Int, signature string, stellarAddress string) error {
+func (s *SubstrateClient) ProposeBurnTransactionOrAddSig(identity *Identity, txID uint64, target AccountID, amount *big.Int, signature string, stellarAddress string, sequence_number uint64) (*types.Call, error) {
 	c, err := types.NewCall(s.meta, "TFTBridgeModule.propose_burn_transaction_or_add_sig",
-		txID, target, types.U64(amount.Uint64()), signature, stellarAddress,
+		txID, target, types.U64(amount.Uint64()), signature, stellarAddress, sequence_number,
 	)
 
 	if err != nil {
-		return errors.Wrap(err, "failed to create call")
+		return nil, errors.Wrap(err, "failed to create call")
 	}
 
-	if _, err := s.call(identity, c); err != nil {
-		return errors.Wrap(err, "failed to propose or add sig for a burn transaction")
-	}
+	// if _, err := s.call(identity, c); err != nil {
+	// 	return errors.Wrap(err, "failed to propose or add sig for a burn transaction")
+	// }
 
-	return nil
+	return &c, nil
 }
 
-func (s *SubstrateClient) SetBurnTransactionExecuted(identity *Identity, txID uint64) error {
+func (s *SubstrateClient) SetBurnTransactionExecuted(identity *Identity, txID uint64) (*types.Call, error) {
 	log.Debug().Msg("setting burn transaction as executed")
 	c, err := types.NewCall(s.meta, "TFTBridgeModule.set_burn_transaction_executed", txID)
 
 	if err != nil {
-		return errors.Wrap(err, "failed to create call")
+		return nil, errors.Wrap(err, "failed to create call")
 	}
 
-	if _, err := s.call(identity, c); err != nil {
-		return errors.Wrap(err, "failed to set burn transaction executed")
-	}
+	// if _, err := s.call(identity, c); err != nil {
+	// 	return errors.Wrap(err, "failed to set burn transaction executed")
+	// }
 
-	return nil
+	return &c, nil
 }
 
 func (s *SubstrateClient) GetBurnTransaction(identity *Identity, burnTransactionID types.U64) (*BurnTransaction, error) {

--- a/tfchain_bridge/pkg/substrate/client.go
+++ b/tfchain_bridge/pkg/substrate/client.go
@@ -58,6 +58,10 @@ func (s *SubstrateClient) Refresh() error {
 	return nil
 }
 
+func (s *SubstrateClient) GetMeta() *types.Metadata {
+	return s.meta
+}
+
 func (s *SubstrateClient) getVersion(b types.StorageDataRaw) (uint32, error) {
 	var ver Versioned
 	if err := types.DecodeFromBytes(b, &ver); err != nil {
@@ -67,7 +71,7 @@ func (s *SubstrateClient) getVersion(b types.StorageDataRaw) (uint32, error) {
 	return ver.Version, nil
 }
 
-func (s *SubstrateClient) call(identity *Identity, call types.Call) (hash types.Hash, err error) {
+func (s *SubstrateClient) Call(identity *Identity, call types.Call) (hash types.Hash, err error) {
 	// Create the extrinsic
 	ext := types.NewExtrinsic(call)
 

--- a/tfchain_bridge/pkg/substrate/minting.go
+++ b/tfchain_bridge/pkg/substrate/minting.go
@@ -48,18 +48,18 @@ func (s *SubstrateClient) IsMintedAlready(identity *Identity, mintTxID string) (
 	return true, nil
 }
 
-func (s *SubstrateClient) ProposeOrVoteMintTransaction(identity *Identity, txID string, target AccountID, amount *big.Int) error {
+func (s *SubstrateClient) ProposeOrVoteMintTransaction(identity *Identity, txID string, target AccountID, amount *big.Int) (*types.Call, error) {
 	c, err := types.NewCall(s.meta, "TFTBridgeModule.propose_or_vote_mint_transaction",
 		txID, target, types.U64(amount.Uint64()),
 	)
 
 	if err != nil {
-		return errors.Wrap(err, "failed to create call")
+		return nil, errors.Wrap(err, "failed to create call")
 	}
 
-	if _, err := s.call(identity, c); err != nil {
-		return errors.Wrap(err, "failed to propose or vote mint transaction")
-	}
+	// if _, err := s.call(identity, c); err != nil {
+	// 	return errors.Wrap(err, "failed to propose or vote mint transaction")
+	// }
 
-	return nil
+	return &c, nil
 }

--- a/tfchain_bridge/pkg/substrate/refunds.go
+++ b/tfchain_bridge/pkg/substrate/refunds.go
@@ -8,42 +8,43 @@ import (
 )
 
 type RefundTransaction struct {
-	Block      types.U32
-	Amount     types.U64
-	Target     string
-	TxHash     string
-	Signatures []pkg.StellarSignature
+	Block          types.U32
+	Amount         types.U64
+	Target         string
+	TxHash         string
+	Signatures     []pkg.StellarSignature
+	SequenceNumber types.U64
 }
 
-func (s *SubstrateClient) CreateRefundTransactionOrAddSig(identity *Identity, tx_hash string, target string, amount int64, signature string, stellarAddress string) error {
+func (s *SubstrateClient) CreateRefundTransactionOrAddSig(identity *Identity, tx_hash string, target string, amount int64, signature string, stellarAddress string, sequence_number uint64) (*types.Call, error) {
 	c, err := types.NewCall(s.meta, "TFTBridgeModule.create_refund_transaction_or_add_sig",
-		tx_hash, target, types.U64(amount), signature, stellarAddress,
+		tx_hash, target, types.U64(amount), signature, stellarAddress, sequence_number,
 	)
 
 	if err != nil {
-		return errors.Wrap(err, "failed to create call")
+		return nil, errors.Wrap(err, "failed to create call")
 	}
 
-	if _, err := s.call(identity, c); err != nil {
-		return errors.Wrap(err, "failed to propose or add sig for a refund transaction")
-	}
+	// if _, err := s.call(identity, c); err != nil {
+	// 	return errors.Wrap(err, "failed to propose or add sig for a refund transaction")
+	// }
 
-	return nil
+	return &c, nil
 }
 
-func (s *SubstrateClient) SetRefundTransactionExecuted(identity *Identity, txHash string) error {
+func (s *SubstrateClient) SetRefundTransactionExecuted(identity *Identity, txHash string) (*types.Call, error) {
 	log.Debug().Msg("setting refund transaction as executed")
 	c, err := types.NewCall(s.meta, "TFTBridgeModule.set_refund_transaction_executed", txHash)
 
 	if err != nil {
-		return errors.Wrap(err, "failed to create call")
+		return nil, errors.Wrap(err, "failed to create call")
 	}
 
-	if _, err := s.call(identity, c); err != nil {
-		return errors.Wrap(err, "failed to set refund transaction executed")
-	}
+	// if _, err := s.call(identity, c); err != nil {
+	// 	return errors.Wrap(err, "failed to set refund transaction executed")
+	// }
 
-	return nil
+	return &c, nil
 }
 
 func (s *SubstrateClient) IsRefundedAlready(identity *Identity, txHash string) (exists bool, err error) {


### PR DESCRIPTION
- Adds a queue so events from substrate are read sequentially
- Improves Stellar transaction submission by saving the sequence number on chain. This to prevent wrong sequence number when submitting the final transaction.